### PR TITLE
Add navigation via arrow keys & swipe gestures

### DIFF
--- a/index.html
+++ b/index.html
@@ -1077,8 +1077,9 @@ body::-webkit-scrollbar {
 		else if (focus_name == 999) return 'Images/999.gif';
 
 		const graf = graf_data.get(focus_name);
-		if(mode === 'Lines' && !graf.noL) {
-			return thumb.replace('Images_thumb','Lines');
+		if(mode === 'Lines') {
+			if(graf.noL) return thumb.replace(/(Images|Lines)_thumb/,'Images');
+			return thumb.replace(/(Images|Lines)_thumb/,'Lines');
 		}
 		return thumb.replace('_thumb','');
 	}

--- a/index.html
+++ b/index.html
@@ -363,6 +363,18 @@ body::-webkit-scrollbar {
 	background-color: #8B0000;
 	transition:200ms;
 }
+
+#swipe-indicator {
+	position: absolute;
+	z-index: 100;
+	text-align: center;
+	vertical-align: center;
+	font-size: 48px;
+	color: white;
+	background-color: black;
+	border-radius: 50%;
+	border: 2px solid black;
+	box-shadow: 0 0 4px 4px rgba(0,0,0,1);
 }
 
 </style>
@@ -1394,6 +1406,12 @@ body::-webkit-scrollbar {
 	}
 
 	function focusAtOffset(offset) {
+		// just in case
+		if(swipeIndicator) {
+			swipeIndicator.remove();
+			swipeIndicator = null;
+		}
+
 		if(!focus_name) return;
 		if(document.getElementById("focusbox").classList.contains("hidden")) return;
 
@@ -1426,9 +1444,18 @@ body::-webkit-scrollbar {
 	});
 
 	let touchStartedX = null;
+	let swipeIndicator = null;
 
 	document.addEventListener('touchstart', function (event) {
 		touchStartedX = event.touches[0].clientX;
+		swipeIndicator = document.createElement('div');
+		swipeIndicator.id = 'swipe-indicator';
+
+		const focusImgHeight = document.getElementById('focusimg').clientHeight;
+		swipeIndicator.style.top = `${focusImgHeight/2}px`;
+		swipeIndicator.style.opacity = 0;
+
+		document.getElementById('focusbox').appendChild(swipeIndicator);
 	});
 
 	document.addEventListener('touchend', function (event) {
@@ -1441,7 +1468,36 @@ body::-webkit-scrollbar {
 		if(diff < -50) {
 			focusAtOffset(1);
 		}
+		if(swipeIndicator) {
+			swipeIndicator.remove();
+			swipeIndicator = null;
+		}
 		touchStartedX = null;
+	});
+
+	document.addEventListener('touchmove', function (event) {
+		const touchMoveOffset = event.touches[0].clientX - touchStartedX;
+		const side = touchMoveOffset > 0 ? 'left' : 'right';
+		const notSide = side === 'left' ? 'right' : 'left';
+		const focusImgWidth = document.getElementById('focusimg').clientWidth;
+		const swipeLength = Math.floor(focusImgWidth * 0.6);
+		const maxPosition = Math.floor(focusImgWidth / 2);
+		const swipeProgress = Math.min(Math.abs(touchMoveOffset), swipeLength) / swipeLength;
+
+		const size = Math.floor(focusImgWidth * 0.1);
+		const fontSize = Math.floor(size * 0.6);
+		const opacity = swipeProgress * 0.9;
+		const offset = Math.min(Math.abs(touchMoveOffset), maxPosition) - size / 2;
+
+		swipeIndicator.innerHTML = touchMoveOffset > 0 ? '&#x2190;' : '&#x2192;';
+		swipeIndicator.style[side] = `${offset}px`;
+		swipeIndicator.style[notSide] = 'auto';
+		swipeIndicator.style.lineHeight = `${size}px`;
+		swipeIndicator.style.height = `${size}px`;
+		swipeIndicator.style.width = `${size}px`;
+		swipeIndicator.style.fontSize = `${fontSize}px`;
+		swipeIndicator.style.marginTop = `-${size/2}px`;
+		swipeIndicator.style.opacity = opacity;
 	});
 	
 	var centerjump = 0;

--- a/index.html
+++ b/index.html
@@ -1451,6 +1451,10 @@ body::-webkit-scrollbar {
 	let swipeIndicator = null;
 
 	document.addEventListener('touchstart', function (event) {
+		if(swipeIndicator) {
+			swipeIndicator.remove();
+			swipeIndicator = null;
+		}
 		touchStartedX = event.touches[0].clientX;
 		swipeIndicator = document.createElement('div');
 		swipeIndicator.id = 'swipe-indicator';

--- a/index.html
+++ b/index.html
@@ -1076,6 +1076,11 @@ body::-webkit-scrollbar {
 	function getImageSrcFromThumb(thumb) {
 		if (focus_name == 226) return 'Images/226.gif';
 		else if (focus_name == 999) return 'Images/999.gif';
+
+		const graf = graf_data.get(focus_name);
+		if(mode === 'Lines' && !graf.noL) {
+			return thumb.replace('Images_thumb','Lines');
+		}
 		return thumb.replace('_thumb','');
 	}
 	

--- a/index.html
+++ b/index.html
@@ -1428,7 +1428,6 @@ body::-webkit-scrollbar {
 	let touchStartedX = null;
 
 	document.addEventListener('touchstart', function (event) {
-		console.log({event});
 		touchStartedX = event.touches[0].clientX;
 	});
 

--- a/index.html
+++ b/index.html
@@ -1424,6 +1424,26 @@ body::-webkit-scrollbar {
 			hideFocus();
 		}
 	});
+
+	let touchStartedX = null;
+
+	document.addEventListener('touchstart', function (event) {
+		console.log({event});
+		touchStartedX = event.touches[0].clientX;
+	});
+
+	document.addEventListener('touchend', function (event) {
+		if(touchStartedX === null) return;
+		const touchEndedX = event.changedTouches[0].clientX;
+		const diff = touchEndedX - touchStartedX;
+		if(diff > 50) {
+			focusAtOffset(-1);
+		}
+		if(diff < -50) {
+			focusAtOffset(1);
+		}
+		touchStartedX = null;
+	});
 	
 	var centerjump = 0;
 	reblockGrid()

--- a/index.html
+++ b/index.html
@@ -1388,6 +1388,35 @@ body::-webkit-scrollbar {
 		document.getElementById("jumpto").value = Number(goto_num);
 		setTimeout(() => { jumpTo('bypass'); focusImage('img'+goto_num,'Images_thumb/'+goto_num+'.webp') }, "200");
 	}
+
+	function focusAtOffset(offset) {
+		if(!focus_name) return;
+		if(document.getElementById("focusbox").classList.contains("hidden")) return;
+
+		const currentThumb = document.getElementById(`img${focus_name}`);
+		// grab all images regardless of season
+		const allImages = Array.from(document.querySelectorAll('div#contentbox img')).filter(el => el.id.startsWith('img'));
+		const index = allImages.indexOf(currentThumb);
+		const desiredIndex = index + offset;
+		// ignore under/overruns because that's the spirit of JS
+		const desiredThumb = allImages[desiredIndex];
+
+		if(desiredThumb) {
+			focusImage(desiredThumb.id, desiredThumb.src);
+		}
+	}
+
+	document.addEventListener('keydown', function (event) {
+		if(event.key === 'ArrowRight') {
+			focusAtOffset(1);
+		}
+		if(event.key === 'ArrowLeft') {
+			focusAtOffset(-1);
+		}
+		if(event.key === 'Escape') {
+			hideFocus();
+		}
+	});
 	
 	var centerjump = 0;
 	reblockGrid()

--- a/index.html
+++ b/index.html
@@ -1060,6 +1060,12 @@ body::-webkit-scrollbar {
 			document.getElementById("focusvid").style.display = 'none';
 		}
 	}
+
+	function getImageSrcFromThumb(thumb) {
+		if (focus_name == 226) return 'Images/226.gif';
+		else if (focus_name == 999) return 'Images/999.gif';
+		return thumb.replace('_thumb','');
+	}
 	
 	var stay_hearts = 0; // Prevents toggling back to normal after clicking hearts button - reset on reloading focus_box
 	var focus_name = 0;
@@ -1072,9 +1078,7 @@ body::-webkit-scrollbar {
 		focus_img = document.getElementById("focusimg");
 		if (mode=='Lines' && graf.noL) { focus_img.classList.add("gray"); }
 		else { focus_img.classList.remove("gray"); }
-		if ( focus_name==226 ) { focus_img.src = 'Images/226.gif';}
-		else if ( focus_name==999 ) { focus_img.src = 'Images/999.gif';}
-		else { focus_img.src = src.replace('_thumb','');}
+		focus_img.src = getImageSrcFromThumb(src);
 		//document.getElementById("focusbox").requestFullscreen();
 		
 		like_button = document.getElementById('like');
@@ -1401,9 +1405,12 @@ body::-webkit-scrollbar {
 		// ignore under/overruns because that's the spirit of JS
 		const desiredThumb = allImages[desiredIndex];
 
-		if(desiredThumb) {
-			focusImage(desiredThumb.id, desiredThumb.src);
-		}
+		if(!desiredThumb) return;
+
+		// try to preload it to avoid tags 'n' stuff jumping around while the image dimensions get figured out
+		const img = new Image();
+		img.onload = () => focusImage(desiredThumb.id, desiredThumb.src);
+		img.src = getImageSrcFromThumb(desiredThumb.src);
 	}
 
 	document.addEventListener('keydown', function (event) {

--- a/index.html
+++ b/index.html
@@ -369,12 +369,11 @@ body::-webkit-scrollbar {
 	z-index: 100;
 	text-align: center;
 	vertical-align: middle;
-	font-size: 48px;
-	color: white;
-	background-color: black;
 	border-radius: 50%;
-	border: 2px solid black;
-	box-shadow: 0 0 4px 4px rgba(0,0,0,1);
+	background-image: url('Assets/b_back.png');
+	background-repeat: no-repeat;
+	background-position: center;
+	background-size: cover;
 }
 
 </style>
@@ -1497,7 +1496,7 @@ body::-webkit-scrollbar {
 		const opacity = swipeProgress * 0.9;
 		const offset = Math.min(Math.abs(touchMoveOffset), maxPosition) - size / 2;
 
-		swipeIndicator.innerHTML = touchMoveOffset > 0 ? '&#x2190;' : '&#x2192;';
+		swipeIndicator.style.transform = touchMoveOffset > 0 ? 'rotate(0deg)' : 'rotate(180deg)';
 		swipeIndicator.style[side] = `${offset}px`;
 		swipeIndicator.style[notSide] = 'auto';
 		swipeIndicator.style.lineHeight = `${size}px`;

--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@ body::-webkit-scrollbar {
 	position: absolute;
 	z-index: 100;
 	text-align: center;
-	vertical-align: center;
+	vertical-align: middle;
 	font-size: 48px;
 	color: white;
 	background-color: black;
@@ -1465,12 +1465,15 @@ body::-webkit-scrollbar {
 
 	document.addEventListener('touchend', function (event) {
 		if(touchStartedX === null) return;
+
+		const threshold = 100; // minimum swipe length before it counts as a swipe
+
 		const touchEndedX = event.changedTouches[0].clientX;
 		const diff = touchEndedX - touchStartedX;
-		if(diff > 50) {
+		if(diff > threshold) {
 			focusAtOffset(-1);
 		}
-		if(diff < -50) {
+		if(diff < -threshold) {
 			focusAtOffset(1);
 		}
 		if(swipeIndicator) {
@@ -1489,7 +1492,7 @@ body::-webkit-scrollbar {
 		const maxPosition = Math.floor(focusImgWidth / 2);
 		const swipeProgress = Math.min(Math.abs(touchMoveOffset), swipeLength) / swipeLength;
 
-		const size = Math.floor(focusImgWidth * 0.1);
+		const size = Math.floor(focusImgWidth * 0.1 + swipeProgress * 30);
 		const fontSize = Math.floor(size * 0.6);
 		const opacity = swipeProgress * 0.9;
 		const offset = Math.min(Math.abs(touchMoveOffset), maxPosition) - size / 2;


### PR DESCRIPTION
## Overview

This PR introduces a couple of features aimed at increasing the one-handed usability of this project.
#### Navigation between images using the arrow keys
The left and right arrow keys can now be used to navigate through the list of images without having to close the currently viewed one. This behavior respects the current search and sort settings (which was a bit more problematic than expected). A keybind is also added to close the image viewer with Escape.
#### Swipe gestures on mobile devices
Simple touch handlers are added, which just call the above described navigation logic. This allows swiping left/right to navigate. I was far too lazy to implement the "slide between images" effect, so you get an indicator arrow from the side similar to swiping through Chrome history with a touchpad, or the back gesture in some Android distributions. The indicator's size/opacity animate along with the swipe.

## Changes
- added `focusAtOffset` function, reads the DOM to determine the order & navigates
- added a couple of key event handlers to do the navigation
- pulled out a bit of logic from `focusImage` into `getImageSrcFromThumb`
- used that to preload images before showing (to avoid content jumping around)
- added a primitive, and perhaps naive, touch event handler to call the same navigation behavior
- added some indicator arrows that show up during the swipe gesture, animated according to the swipe motion

## Verification
Platforms and browsers tested:
Firefox: Mac, Windows, Linux, Android, iOS\*
Chrome: Mac, Windows, Linux, Android, iOS\*
Edge: Mac, Windows, Linux, Android, iOS
Safari: Mac, iOS
<sub>\* it's just a Safari skin</sub>

https://github.com/user-attachments/assets/24d27de8-a8c2-4eeb-9844-44de47781722

https://github.com/user-attachments/assets/ae33ce24-0f06-4a43-a493-b1119cdbc82d

Pardon the user inputs not being visible, but setting that up was more effort than I could be bothered with at the moment. This is navigation using the arrow keys:

https://github.com/user-attachments/assets/6b981bf7-c3ee-4945-b80b-8111cc6d5018

## Quirks
Firefox on Android has a quirk where if you swipe sideways but also a bit down, it'll trigger the pull-to-refresh functionality and interrupt the swipe, leaving the indicator in place. It'll get cleaned up next time there's a touch event. Working around that would be a tremendous pain in the ass. As expected from Firefox on Android.